### PR TITLE
Fix uvicorn entry point

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Prediction Pulse API"}
+


### PR DESCRIPTION
## Summary
- add a simple FastAPI app entry point so `uvicorn api:app` works

## Testing
- `pip install -r requirements.txt`
- `uvicorn api:app --host 0.0.0.0 --port 10000`

------
https://chatgpt.com/codex/tasks/task_e_685cb9adf1ec8321a82762f5ee46dd7f