### PR TITLE
Load Supabase key from external config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local environment files
+.env
+# Browser config with secrets
+public/config.js

--- a/public/config.example.js
+++ b/public/config.example.js
@@ -1,0 +1,3 @@
+// Copy this file to config.js and fill in your Supabase credentials
+window.SUPABASE_URL = "https://YOUR_PROJECT.supabase.co";
+window.SUPABASE_KEY = "YOUR_SUPABASE_ANON_KEY";

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,8 @@
 
   <canvas id="trendChart" style="max-width: 600px; margin-top: 2rem;"></canvas>
 
+  <!-- Config with Supabase credentials (not checked into git) -->
+  <script src="config.js"></script>
   <!-- Load custom script -->
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,6 @@
-const SUPABASE_URL = "https://eypantouzmwgauobeywr.supabase.co";
-const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cGFudG91em13Z2F1b2JleXdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc4Nzk5MzYsImV4cCI6MjA2MzQ1NTkzNn0.SyDUsU6IqkUqH8TLkNX8nNCYzcjZZ4CUvVqUzt1w8TI"; // 🔐 You can keep it in .env or obfuscate if exposed
+// URL and anon key are provided by public/config.js (git‑ignored)
+const SUPABASE_URL = window.SUPABASE_URL;
+const SUPABASE_KEY = window.SUPABASE_KEY;
 
 let chart, sortKey = "volume", sortDir = "desc";
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,18 @@
 
 Add them to **`.env`** for local runs and **GitHub Secrets** for CI.
 
+### Front-end config
+
+The demo page in `public/` reads credentials from `public/config.js`. Create it
+from the example and fill in your values:
+
+```bash
+cp public/config.example.js public/config.js
+# edit with your SUPABASE_URL and anon key
+```
+
+`config.js` is ignored by git so your key won't be committed.
+
 ---
 
 ## 🔃 Scheduled jobs


### PR DESCRIPTION
## Summary
- hide browser config file with `.gitignore`
- read Supabase credentials from `public/config.js`
- document how to configure the new file

## Testing
- `python -m py_compile $(ls *.py)` *(fails: SyntaxError in kalshi_fetch.py)*

------
https://chatgpt.com/codex/tasks/task_e_685cb9b8f7908321857cfc062c2706a9