### PR TITLE
Add AI Summary column

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
         <th data-sort="volume">Volume</th>
         <th data-sort="expiration">Expiration</th>
         <th data-sort="changePct">24h Change</th>
+        <th data-sort="summary">AI Summary</th>
       </tr>
     </thead>
     <tbody id="marketTable"></tbody>

--- a/public/script.js
+++ b/public/script.js
@@ -18,7 +18,7 @@ async function loadMarkets() {
   try {
     let rows = await api(
       `/rest/v1/latest_snapshots` +
-      `?select=market_id,source,price,volume,timestamp,market_name,event_name,expiration` +
+      `?select=market_id,source,price,volume,timestamp,market_name,event_name,expiration,summary` +
       `&limit=1000`
     );
 
@@ -66,9 +66,15 @@ function renderTable(rows) {
   tbody.innerHTML = "";
 
   rows.sort((a, b) => {
-    const va = a[sortKey] ?? -Infinity;
-    const vb = b[sortKey] ?? -Infinity;
-    return sortDir === "desc" ? vb - va : va - vb;
+    const va = a[sortKey];
+    const vb = b[sortKey];
+    if (typeof va === "string" || typeof vb === "string") {
+      const cmp = String(va).localeCompare(String(vb));
+      return sortDir === "desc" ? -cmp : cmp;
+    }
+    const numA = va ?? -Infinity;
+    const numB = vb ?? -Infinity;
+    return sortDir === "desc" ? numB - numA : numA - numB;
   });
 
   rows.forEach(r => {
@@ -84,6 +90,7 @@ function renderTable(rows) {
         <td>${r.volume == null ? "—" : `$${Number(r.volume).toLocaleString()}`}</td>
         <td>${r.expiration ? new Date(r.expiration).toLocaleDateString() : "—"}</td>
         <td>${arrow} ${changeDisp}</td>
+        <td>${r.summary ? r.summary : "—"}</td>
       </tr>`;
 
     tbody.insertAdjacentHTML("beforeend", rowHtml);

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,9 @@ cp public/config.example.js public/config.js
 
 `config.js` is ignored by git so your key won't be committed.
 
+The table on the demo page now includes an **AI Summary** column when the
+`latest_snapshots` view exposes a `summary` field.
+
 ---
 
 ## 🔃 Scheduled jobs


### PR DESCRIPTION
## Summary
- support `summary` field from `latest_snapshots`
- render new **AI Summary** column in the demo table
- document new column in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cc40962648321857e1521ce9129e3