### PR TITLE
Add snapshot cleanup script and GitHub workflow

### DIFF
--- a/.github/workflows/cleanup_snapshots.yml
+++ b/.github/workflows/cleanup_snapshots.yml
@@ -1,0 +1,29 @@
+name: Cleanup Snapshots
+
+on:
+  schedule:
+    - cron: "0 7 * * *"          # daily @ 07:00 UTC
+  workflow_dispatch:
+
+jobs:
+  prune-snapshots:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Remove old snapshots
+        env:
+          SUPABASE_URL:              ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          CUTOFF=$(date -u --iso-8601=seconds -d '90 days ago')
+          python cleanup_snapshots.py "$CUTOFF"

--- a/cleanup_snapshots.py
+++ b/cleanup_snapshots.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Delete old market snapshots from Supabase.
+
+Usage:
+  python cleanup_snapshots.py <ISO8601 timestamp>
+
+A cutoff timestamp can also be provided via the SNAPSHOT_CUTOFF environment
+variable.
+"""
+
+import os
+import sys
+import requests
+
+SUPABASE_URL = os.environ["SUPABASE_URL"]
+SERVICE_KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+
+HEADERS = {
+    "apikey": SERVICE_KEY,
+    "Authorization": f"Bearer {SERVICE_KEY}",
+    "Content-Type": "application/json",
+}
+
+def main(cutoff: str) -> None:
+    url = f"{SUPABASE_URL}/rest/v1/market_snapshots?timestamp=lt.{cutoff}"
+    r = requests.delete(url, headers=HEADERS, timeout=30)
+    if r.status_code not in (200, 204):
+        print(f"❌ delete failed {r.status_code}: {r.text[:200]}")
+    else:
+        print(f"✅ deleted snapshots older than {cutoff}")
+
+if __name__ == "__main__":
+    cutoff = sys.argv[1] if len(sys.argv) > 1 else os.getenv("SNAPSHOT_CUTOFF")
+    if not cutoff:
+        print("Provide cutoff timestamp as argument or SNAPSHOT_CUTOFF env var")
+        sys.exit(1)
+    main(cutoff)


### PR DESCRIPTION
## Summary
- add a `cleanup_snapshots.py` helper script to remove old market_snapshots
- schedule a daily workflow to prune snapshots older than 90 days

## Testing
- `python -m py_compile cleanup_snapshots.py`
- `pip install -r requirements.txt` *(already satisfied)*
- `python cleanup_snapshots.py 2021-01-01T00:00:00Z` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861e673477c8321b9a798294104a591