### PR TITLE
Use config.js module for Supabase creds

### DIFF
--- a/public/config.example.js
+++ b/public/config.example.js
@@ -1,3 +1,3 @@
 // Copy this file to config.js and fill in your Supabase credentials
-window.SUPABASE_URL = "https://YOUR_PROJECT.supabase.co";
-window.SUPABASE_KEY = "YOUR_SUPABASE_ANON_KEY";
+export const SUPABASE_URL = "https://YOUR_PROJECT.supabase.co";
+export const SUPABASE_KEY = "YOUR_SUPABASE_ANON_KEY";

--- a/public/index.html
+++ b/public/index.html
@@ -36,9 +36,7 @@
 
   <canvas id="trendChart" style="max-width: 600px; margin-top: 2rem;"></canvas>
 
-  <!-- Config with Supabase credentials (not checked into git) -->
-  <script src="config.js"></script>
-  <!-- Load custom script -->
-  <script src="script.js"></script>
+  <!-- Load main script which imports config.js for credentials -->
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,6 +1,5 @@
-// URL and anon key are provided by public/config.js (git‑ignored)
-const SUPABASE_URL = window.SUPABASE_URL;
-const SUPABASE_KEY = window.SUPABASE_KEY;
+// Import Supabase credentials from config.js (not committed to git)
+import { SUPABASE_URL, SUPABASE_KEY } from "./config.js";
 
 let chart, sortKey = "volume", sortDir = "desc";
 


### PR DESCRIPTION
## Summary
- export Supabase credentials in `public/config.example.js`
- import these credentials in `script.js`
- load `script.js` as a module from `index.html`

`public/config.js` is now a gitignored module created from the example.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f166d24c83219ba16763f4594950