### PR TITLE
Add build step to generate frontend config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Local environment files
 .env
 public/config.js
+webapp/public/config.js
 
 # Node modules
 node_modules/
@@ -18,3 +19,4 @@ dist/
 .env
 # Browser config with secrets
 public/config.js
+webapp/public/config.js

--- a/generate-config.js
+++ b/generate-config.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const url = process.env.VITE_SUPABASE_URL;
+const key = process.env.VITE_SUPABASE_KEY;
+
+if (!url || !key) {
+  console.error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_KEY');
+  process.exit(1);
+}
+
+const outDir = path.join(__dirname, 'webapp', 'public');
+fs.mkdirSync(outDir, { recursive: true });
+
+const content = `export const SUPABASE_URL = ${JSON.stringify(url)};\nexport const SUPABASE_KEY = ${JSON.stringify(key)};\n`;
+fs.writeFileSync(path.join(outDir, 'config.js'), content);
+console.log('Wrote', path.join(outDir, 'config.js'));
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+  command = "node generate-config.js && npm run --prefix webapp build"
+  publish = "webapp/dist"
+
 [[headers]]
 for = "/*"
   [headers.values]


### PR DESCRIPTION
## Summary
- add script `generate-config.js` to write Supabase credentials into `webapp/public/config.js`
- ignore generated config in `.gitignore`
- run script before building Vite app via `netlify.toml`

## Testing
- `pytest -q`
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_KEY=anon123 node generate-config.js`

------
https://chatgpt.com/codex/tasks/task_e_686df41e8ae4832184876e04826688b4