### PR TITLE
Fix Netlify build for Vite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  command = "node generate-config.js && npm run --prefix webapp build"
+  # install frontend deps since the repo root has no package.json
+  command = "node generate-config.js && npm ci --prefix webapp && npm run --prefix webapp build"
   publish = "webapp/dist"
 
 [[headers]]

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,18 @@ The `tags` column is `jsonb`; just pass a Python list (`["econ","CPI"]`).
 The `webapp/` directory contains a small React app built with [Vite](https://vitejs.dev/).
 Run `npm install` inside that folder and `npm run dev` to start a local preview.
 
+### Netlify
+
+Netlify doesn't run `npm install` automatically because the repo root lacks a
+`package.json`. The `netlify.toml` build command therefore installs the webapp
+dependencies explicitly:
+
+```toml
+[build]
+  command = "node generate-config.js && npm ci --prefix webapp && npm run --prefix webapp build"
+  publish = "webapp/dist"
+```
+
 ---
 
 ## 🛣 Roadmap


### PR DESCRIPTION
## Summary
- install webapp dependencies during Netlify build
- document Netlify install step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2b75570883219fca57a285017f79