### PR TITLE
Fix Netlify secret scan on public key

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,10 @@
   command = "node generate-config.js && npm ci --prefix webapp && npm run --prefix webapp build"
   publish = "webapp/dist"
 
+[build.environment]
+  # Skip Netlify secrets scanning for the public Supabase anon key
+  SECRETS_SCAN_OMIT_KEYS = "VITE_SUPABASE_KEY"
+
 [[headers]]
 for = "/*"
   [headers.values]


### PR DESCRIPTION
## Summary
- disable secret scanning for the exposed Supabase anon key

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f2ff748148321bf94ab7a45f21d47