### PR TITLE
Remove SUPABASE_KEY references

### DIFF
--- a/public/config.example.js
+++ b/public/config.example.js
@@ -1,3 +1,3 @@
 // Copy this file to config.js and fill in your Supabase credentials
 export const SUPABASE_URL = "https://YOUR_PROJECT.supabase.co";
-export const SUPABASE_KEY = "YOUR_SUPABASE_ANON_KEY";
+export const SUPABASE_ANON_KEY = "YOUR_SUPABASE_ANON_KEY";

--- a/public/script.js
+++ b/public/script.js
@@ -1,11 +1,11 @@
 // Import Supabase credentials from config.js (not committed to git)
-import { SUPABASE_URL, SUPABASE_KEY } from "./config.js";
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./config.js";
 
 let chart, sortKey = "volume", sortDir = "desc";
 let sourceFilter = "all", categoryFilter = "all";
 
 function api(path) {
-  if (!SUPABASE_URL || !SUPABASE_KEY || SUPABASE_URL.includes("YOUR_PROJECT")) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY || SUPABASE_URL.includes("YOUR_PROJECT")) {
     return Promise.reject(
       new Error(
         "Supabase credentials missing. Copy public/config.example.js to public/config.js and set your project URL and anon key."
@@ -13,7 +13,7 @@ function api(path) {
     );
   }
   return fetch(`${SUPABASE_URL}${path}`, {
-    headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}` },
     mode: "cors"
   }).then(async res => {
     if (!res.ok) throw new Error(`Supabase ${res.status}: ${await res.text()}`);

--- a/readme.md
+++ b/readme.md
@@ -65,8 +65,8 @@ See **`.env.example`** for a template and add them to **`.env`** for local runs.
 
 ### Front-end config
 
-The React app in `webapp/` pulls Supabase credentials from environment
-variables. For local development:
+The React app in `webapp/` uses just two environment variables:
+`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. For local development:
 
 ```bash
 cp webapp/.env.example webapp/.env

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,7 +1,6 @@
 
 # Copy this file to .env and fill in your Supabase credentials
 SUPABASE_URL="https://your-project.supabase.co"
-SUPABASE_KEY="your-supabase-anon-key"
 
 VITE_SUPABASE_URL="https://your-project.supabase.co"
 VITE_SUPABASE_ANON_KEY="your-anon-key"

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react'
 import './App.css'
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
-const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 async function api(path) {
   const res = await fetch(`${SUPABASE_URL}${path}`, {
-    headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}` },
     mode: 'cors'
   })
   if (!res.ok) throw new Error(`Supabase ${res.status}: ${await res.text()}`)


### PR DESCRIPTION
## Summary
- drop `SUPABASE_KEY` from webapp `.env.example`
- use `SUPABASE_ANON_KEY` throughout frontend code
- update frontend config docs in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff411916c83218c9cd8041412cae7