### PR TITLE
Improve latest_snapshots table

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -25,7 +25,7 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -65,4 +65,29 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+}
+
+thead {
+  background: #f1f1f1;
+}
+
+th, td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #e0e0e0;
+  text-align: left;
+}
+
+.outcome-row td:first-child {
+  width: 1rem;
+}
+
+tr:hover {
+  background-color: #f5faff;
 }


### PR DESCRIPTION
## Summary
- fetch active markets with joined outcome data
- compute price change from 24h ago
- display markets with per‑outcome rows
- add basic table styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687001f8cc948321979a105ca99e4751