### PR TITLE
Update CSP for Chart.js usage

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ for = "/*"
   [headers.values]
   Content-Security-Policy = """
     default-src 'self';
-    script-src  'self' https://cdn.jsdelivr.net;
+    script-src  'self' 'unsafe-eval' https://cdn.jsdelivr.net;
     style-src   'self' 'unsafe-inline';
     connect-src 'self' https://eypantouzmwgauobeywr.supabase.co;
     img-src     'self' data:;


### PR DESCRIPTION
## Summary
- relax content security policy to allow `unsafe-eval` for Chart.js

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703d91ab9c8321be7668d844751fa6