### PR TITLE
Fix CSP for static demo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@
 [[headers]]
 for = "/*"
   [headers.values]
-  Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://eypantouzmwgauobeywr.supabase.co; img-src 'self' data:;"
+  Content-Security-Policy = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://eypantouzmwgauobeywr.supabase.co; img-src 'self' data:;"

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Prediction Pulse</title>
   <link rel="stylesheet" href="style.css">
-  <!-- Pre‑bundled Chart.js UMD build (CSP-safe) -->
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <!-- Chart.js loaded as ES module -->
 </head>
 <body>
   <h1>📊 Prediction Pulse: Top Markets</h1>

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,6 @@
 // Import Supabase credentials from config.js (not committed to git)
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "./config.js";
+import { Chart } from "https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.esm.min.js";
 
 let chart, sortKey = "volume", sortDir = "desc";
 let sourceFilter = "all", categoryFilter = "all";

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,8 @@ On Netlify, set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in your
 site settings. They will be injected at build time via `import.meta.env`.
 
 The old static demo under `public/` still supports a `config.js` file for
-backwards compatibility.
+backwards compatibility. It now imports Chart.js as an ES module so you can
+deploy with a strict CSP and omit `'unsafe-eval'`.
 
 ### Troubleshooting
 

--- a/webapp/public/_headers
+++ b/webapp/public/_headers
@@ -1,0 +1,3 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; connect-src 'self' https://eypantouzmwgauobeywr.supabase.co; img-src 'self' data:;
+


### PR DESCRIPTION
## Summary
- remove `unsafe-eval` from CSP and rely on strict policy
- load Chart.js as an ES module in the static demo
- document that the static demo no longer needs `unsafe-eval`
- include a `_headers` file so Netlify applies the policy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687045824dc883219c23e0e246cb8f4f