### PR TITLE
Fix timestamp encoding in cleanup_snapshots

### DIFF
--- a/cleanup_snapshots.py
+++ b/cleanup_snapshots.py
@@ -22,8 +22,10 @@ HEADERS = {
 }
 
 def main(cutoff: str) -> None:
-    url = f"{SUPABASE_URL}/rest/v1/market_snapshots?timestamp=lt.{cutoff}"
-    r = requests.delete(url, headers=HEADERS, timeout=30)
+    url = f"{SUPABASE_URL}/rest/v1/market_snapshots"
+    r = requests.delete(url, headers=HEADERS,
+                        params={"timestamp": f"lt.{cutoff}"},
+                        timeout=30)
     if r.status_code not in (200, 204):
         print(f"❌ delete failed {r.status_code}: {r.text[:200]}")
     else:


### PR DESCRIPTION
## Summary
- URL encode cutoff timestamp in `cleanup_snapshots.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b281aa4c8321859121b45bbd5685