### PR TITLE
Add POLYMARKET_GAMMA_URL override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 KALSHI_API_KEY="your-kalshi-api-key"
 POLYMARKET_API_KEY="your-polymarket-api-key"
 # Optional overrides when direct access to clob.polymarket.com is blocked
+# POLYMARKET_GAMMA_URL="https://your-proxy.example.com/markets"
 # POLYMARKET_CLOB_URL="https://your-proxy.example.com/markets/{}"
 # POLYMARKET_TRADES_URL="https://your-proxy.example.com/markets/{}/trades"

--- a/common.py
+++ b/common.py
@@ -54,10 +54,12 @@ def insert_to_supabase(table: str, rows: list, conflict_key: str | None = "marke
             print(f"✅ {table}: inserted {len(chunk)} rows")
 
 # ───────────────── Polymarket helpers
-GAMMA_URL = "https://gamma.polymarket.com/markets"
-# Allow overriding the default CLOB endpoints via environment variables. This
-# makes it possible to point the loader at a custom proxy when direct network
-# access is restricted.
+# Allow overriding the default endpoints via environment variables. This makes
+# it possible to point the loader at a custom proxy when direct network access
+# is restricted.
+GAMMA_URL = os.environ.get(
+    "POLYMARKET_GAMMA_URL", "https://gamma.polymarket.com/markets"
+)
 CLOB_URL = os.environ.get(
     "POLYMARKET_CLOB_URL", "https://clob.polymarket.com/markets/{}"
 )

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Planned: deeper summarization models that track *why* probabilities shift over t
 | `SUPABASE_SERVICE_ROLE_KEY` | long service key (server‑side only)   |
 | `KALSHI_API_KEY`            | Kalshi personal API token             |
 | `POLYMARKET_API_KEY`        | (optional) higher quota for Gamma API |
+| `POLYMARKET_GAMMA_URL`      | (optional) override for Gamma API     |
 | `POLYMARKET_CLOB_URL`       | (optional) proxy base for CLOB API    |
 | `POLYMARKET_TRADES_URL`     | (optional) proxy base for trades API  |
 


### PR DESCRIPTION
## Summary
- allow overriding the Polymarket Gamma endpoint via `POLYMARKET_GAMMA_URL`
- document new variable in README and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875be64bc388321a9d9aed835e4e7bd