### PR TITLE
Fix Polymarket Gamma default URL

### DIFF
--- a/common.py
+++ b/common.py
@@ -58,7 +58,7 @@ def insert_to_supabase(table: str, rows: list, conflict_key: str | None = "marke
 # it possible to point the loader at a custom proxy when direct network access
 # is restricted.
 GAMMA_URL = os.environ.get(
-    "POLYMARKET_GAMMA_URL", "https://gamma.polymarket.com/markets"
+    "POLYMARKET_GAMMA_URL", "https://gamma-api.polymarket.com/markets"
 )
 CLOB_URL = os.environ.get(
     "POLYMARKET_CLOB_URL", "https://clob.polymarket.com/markets/{}"


### PR DESCRIPTION
## Summary
- fix `GAMMA_URL` default in `common.py` to use `gamma-api.polymarket.com`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c8debad48321b2294c830315205b