### PR TITLE
Add regression test for Polymarket expiration timezone handling

### DIFF
--- a/tests/test_polymarket_fetch.py
+++ b/tests/test_polymarket_fetch.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+from dateutil.parser import parse
+
+# replicate timezone handling from polymarket_fetch
+
+def normalize_dt(exp_raw):
+    exp_dt = parse(exp_raw)
+    if exp_dt.tzinfo is None:
+        exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+    else:
+        exp_dt = exp_dt.astimezone(timezone.utc)
+    return exp_dt
+
+
+def test_expiration_comparison_naive():
+    now = datetime.now(timezone.utc)
+    exp_dt = normalize_dt("2020-01-01 00:00:00")
+    assert exp_dt <= now
+


### PR DESCRIPTION
## Summary
- ensure comparing parsed Polymarket expiration dates to `datetime.now(timezone.utc)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875cef6a04c83219dc7a0ec0c1c018c