### PR TITLE
Handle Kalshi trade 404s

### DIFF
--- a/kalshi_update_prices.py
+++ b/kalshi_update_prices.py
@@ -73,6 +73,8 @@ def fetch_trade_stats(ticker: str):
             headers=HEADERS_KALSHI,
             timeout=10,
         )
+        if r.status_code == 404:
+            return 0.0, 0, None
         r.raise_for_status()
         trades = r.json().get("trades", [])
         cutoff = datetime.utcnow() - timedelta(hours=24)


### PR DESCRIPTION
## Summary
- prevent error logs from Kalshi trade API when markets return 404s

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876925093ac83219fa3236acd26cc53