### PR TITLE
Fix Kalshi sort for missing volume

### DIFF
--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -128,7 +128,8 @@ def main():
         kept.append(m)
 
     # ✅ unified logic: sort by dollar volume descending
-    kept = sorted(kept, key=lambda m: m.get("dollar_volume_24h", 0), reverse=True)
+    # some markets may lack a volume stat; treat `None` as zero
+    kept = sorted(kept, key=lambda m: m.get("dollar_volume_24h") or 0, reverse=True)
 
     print(f"Filtered down to {len(kept)} markets (skipped {skipped})")
 

--- a/tests/test_kalshi_fetch.py
+++ b/tests/test_kalshi_fetch.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def test_sort_none_dollar_volume():
+    markets = [
+        {"ticker": "A", "dollar_volume_24h": None},
+        {"ticker": "B", "dollar_volume_24h": 100},
+        {"ticker": "C"},
+        {"ticker": "D", "dollar_volume_24h": 50},
+    ]
+    kept = sorted(markets, key=lambda m: m.get("dollar_volume_24h") or 0, reverse=True)
+    assert [m["ticker"] for m in kept] == ["B", "D", "A", "C"]


### PR DESCRIPTION
## Summary
- treat `None` dollar volume as zero when sorting Kalshi markets
- add regression test for sorting with `None` values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769985229c8321806ff8af304648b1