### PR TITLE
Parallelize Kalshi stats fetching

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -16,3 +16,18 @@ def test_chunked_basic():
 def test_chunked_remainder():
     result = list(common._chunked([1, 2, 3, 4, 5], size=2))
     assert result == [[1, 2], [3, 4], [5]]
+
+def test_fetch_stats_concurrent_success():
+    def fn(x):
+        return x * 2
+    stats, failed = common.fetch_stats_concurrent([1, 2, 3], fn)
+    assert dict(stats) == {1: 2, 2: 4, 3: 6}
+    assert failed == []
+
+
+def test_fetch_stats_concurrent_failure():
+    def fn(x):
+        raise ValueError("boom")
+    stats, failed = common.fetch_stats_concurrent([7], fn)
+    assert stats == []
+    assert failed == [7]


### PR DESCRIPTION
## Summary
- add `fetch_stats_concurrent` helper
- update Kalshi loaders to fetch trade stats concurrently
- unit tests for the new helper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68769be174a883219566ba504823c8eb