### PR TITLE
Filter markets within 3 days

### DIFF
--- a/cleanup_snapshots.py
+++ b/cleanup_snapshots.py
@@ -11,6 +11,7 @@ variable.
 import os
 import sys
 import requests
+from datetime import datetime, timezone
 
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SERVICE_KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
@@ -23,13 +24,41 @@ HEADERS = {
 
 def main(cutoff: str) -> None:
     url = f"{SUPABASE_URL}/rest/v1/market_snapshots"
-    r = requests.delete(url, headers=HEADERS,
-                        params={"timestamp": f"lt.{cutoff}"},
-                        timeout=30)
+    r = requests.delete(
+        url,
+        headers=HEADERS,
+        params={"timestamp": f"lt.{cutoff}"},
+        timeout=30,
+    )
     if r.status_code not in (200, 204):
         print(f"❌ delete failed {r.status_code}: {r.text[:200]}")
     else:
         print(f"✅ deleted snapshots older than {cutoff}")
+
+    # remove expired snapshots and markets
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    r = requests.delete(
+        url,
+        headers=HEADERS,
+        params={"expiration": f"lt.{now}"},
+        timeout=30,
+    )
+    if r.status_code in (200, 204):
+        print("✅ deleted expired snapshots")
+    else:
+        print(f"❌ expired snapshot delete failed {r.status_code}: {r.text[:200]}")
+
+    url_m = f"{SUPABASE_URL}/rest/v1/markets"
+    r = requests.delete(
+        url_m,
+        headers=HEADERS,
+        params={"expiration": f"lt.{now}"},
+        timeout=30,
+    )
+    if r.status_code in (200, 204):
+        print("✅ deleted expired markets")
+    else:
+        print(f"❌ expired market delete failed {r.status_code}: {r.text[:200]}")
 
 if __name__ == "__main__":
     cutoff = sys.argv[1] if len(sys.argv) > 1 else os.getenv("SNAPSHOT_CUTOFF")


### PR DESCRIPTION
## Summary
- Kalshi: only keep markets expiring in the next 3 days
- Polymarket: same 3‑day filter and no volume/status filtering
- cleanup script now prunes expired markets and snapshots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876baf3e46c8321bc5af4c812ee2bb1