### PR TITLE
Add websocket client for Kalshi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 KALSHI_API_KEY="your-kalshi-api-key"
+KALSHI_WS_URL="wss://api.elections.kalshi.com/trade-api/ws/v2"  # optional websocket endpoint
 POLYMARKET_API_KEY="your-polymarket-api-key"
 # Optional overrides when direct access to clob.polymarket.com is blocked
 # POLYMARKET_GAMMA_URL="https://your-proxy.example.com/markets"

--- a/kalshi_ws.py
+++ b/kalshi_ws.py
@@ -1,0 +1,23 @@
+import os
+import asyncio
+import json
+import websockets
+
+WS_URL = os.environ.get("KALSHI_WS_URL", "wss://api.elections.kalshi.com/trade-api/ws/v2")
+API_KEY = os.environ.get("KALSHI_API_KEY")
+if not API_KEY:
+    raise RuntimeError("KALSHI_API_KEY must be set")
+
+HEADERS = {"Authorization": f"Bearer {API_KEY}"}
+
+async def listen_ticker():
+    async with websockets.connect(WS_URL, extra_headers=HEADERS, ping_interval=10, ping_timeout=10) as ws:
+        cmd = {"id": 1, "cmd": "subscribe", "params": {"channels": ["ticker_v2"]}}
+        await ws.send(json.dumps(cmd))
+        async for message in ws:
+            data = json.loads(message)
+            if data.get("type") == "ticker_v2":
+                print(json.dumps(data, indent=2))
+
+if __name__ == "__main__":
+    asyncio.run(listen_ticker())

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ The platform aims to:
 # Run once to verify
  python kalshi_fetch.py               # daily metadata load
  python kalshi_update_prices.py       # single price snapshot
+ python kalshi_ws.py                  # live ticker feed via WebSocket
  python market_news_summary.py        # summarize movers w/ news
 ```
 
@@ -49,6 +50,7 @@ The platform aims to:
 ├── common.py                     # shared insert_to_supabase helper
 ├── kalshi_fetch.py               # daily full‑market load
 ├── kalshi_update_prices.py       # 5‑minute snapshots
+├── kalshi_ws.py                 # stream ticker_v2 via WebSocket
 ├── polymarket_fetch.py           # daily full‑market load
 ├── polymarket_update_prices.py   # 5‑minute snapshots
 ├── market_news_summary.py        # summarize big movers
@@ -86,6 +88,7 @@ Planned: deeper summarization models that track *why* probabilities shift over t
 | `SUPABASE_URL`              | e.g. `https://abcde.supabase.co`      |
 | `SUPABASE_SERVICE_ROLE_KEY` | long service key (server‑side only)   |
 | `KALSHI_API_KEY`            | Kalshi personal API token             |
+| `KALSHI_WS_URL`             | (optional) override WebSocket endpoint |
 | `POLYMARKET_API_KEY`        | (optional) higher quota for Gamma API |
 | `POLYMARKET_GAMMA_URL`      | (optional) override for Gamma API     |
 | `POLYMARKET_CLOB_URL`       | (optional) proxy base for CLOB API    |


### PR DESCRIPTION
## Summary
- add `kalshi_ws.py` for streaming ticker data via WebSocket
- include `KALSHI_WS_URL` in `.env.example`
- document new script and variable in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e96f1e8c83218dc6ed97ea85d1e5