### PR TITLE
Add Polymarket events helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,6 @@ KALSHI_WS_URL="wss://api.elections.kalshi.com/trade-api/ws/v2"  # optional webso
 POLYMARKET_API_KEY="your-polymarket-api-key"
 # Optional overrides when direct access to clob.polymarket.com is blocked
 # POLYMARKET_GAMMA_URL="https://your-proxy.example.com/markets"
+# POLYMARKET_EVENTS_URL="https://your-proxy.example.com/events"
 # POLYMARKET_CLOB_URL="https://your-proxy.example.com/markets/{}"
 # POLYMARKET_TRADES_URL="https://your-proxy.example.com/markets/{}/trades"

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ Planned: deeper summarization models that track *why* probabilities shift over t
 | `KALSHI_WS_URL`             | (optional) override WebSocket endpoint |
 | `POLYMARKET_API_KEY`        | (optional) higher quota for Gamma API |
 | `POLYMARKET_GAMMA_URL`      | (optional) override for Gamma API     |
+| `POLYMARKET_EVENTS_URL`     | (optional) override for events API    |
 | `POLYMARKET_CLOB_URL`       | (optional) proxy base for CLOB API    |
 | `POLYMARKET_TRADES_URL`     | (optional) proxy base for trades API  |
 


### PR DESCRIPTION
## Summary
- add `EVENTS_URL` constant with override
- fetch Polymarket events via new `fetch_events` helper
- document optional `POLYMARKET_EVENTS_URL` env variable
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e21fc9808321a4951ad507e7ec8f