### PR TITLE
Simplify front‑end display

### DIFF
--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -27,9 +27,6 @@ function App() {
   const [rows, setRows] = useState([])
   const [sortKey, setSortKey] = useState('volume24h')
   const [sortDir, setSortDir] = useState('desc')
-  const [filter, setFilter] = useState('all')
-  const [category, setCategory] = useState('all')
-  const categories = ['economics', 'politics', 'sports']
   const [error, setError] = useState('')
 
   useEffect(() => {
@@ -53,7 +50,7 @@ function App() {
       const marketsRaw = await api(
         `/rest/v1/latest_snapshots` +
         `?select=market_id,source,market_name,expiration,tags,volume` +
-        `&order=volume.desc&limit=500`
+        `&order=volume.desc&limit=100`
       )
       const markets = marketsRaw.filter(m => !m.expiration || m.expiration > now)
       console.log('Market data from Supabase:', markets.slice(0, 3))
@@ -124,12 +121,7 @@ function App() {
     }
   }
 
-  const displayed = rows
-    .filter(r => filter === 'all' || r.source === filter)
-    .filter(r =>
-      category === 'all' || (r.tags || []).map(t => t.toLowerCase()).includes(category)
-    )
-    .sort((a, b) => {
+  const displayed = [...rows].sort((a, b) => {
       const va = a[sortKey] ?? -Infinity
       const vb = b[sortKey] ?? -Infinity
       return sortDir === 'desc' ? vb - va : va - vb
@@ -138,40 +130,7 @@ function App() {
   return (
     <div className="App">
       <h1>Prediction Pulse: Top Markets</h1>
-      <div className="filters">
-        <button
-          onClick={() => setFilter('all')}
-          className={filter === 'all' ? 'active' : ''}
-        >
-          All
-        </button>
-        <button
-          onClick={() => setFilter('kalshi')}
-          className={filter === 'kalshi' ? 'active' : ''}
-        >
-          Kalshi
-        </button>
-        <button
-          onClick={() => setFilter('polymarket')}
-          className={filter === 'polymarket' ? 'active' : ''}
-        >
-          Polymarket
-        </button>
-      </div>
-      <div className="categories">
-        <button onClick={() => setCategory('all')} className={category === 'all' ? 'active' : ''}>
-          All
-        </button>
-        {categories.map(c => (
-          <button
-            key={c}
-            onClick={() => setCategory(c)}
-            className={category === c ? 'active' : ''}
-          >
-            {c.charAt(0).toUpperCase() + c.slice(1)}
-          </button>
-        ))}
-      </div>
+      {/* removed filters */}
       {error && <p className="error">{error}</p>}
       {!rows.length && !error && <p style={{ color: 'gray' }}>Loading...</p>}
       {rows.length > 0 && (

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -92,13 +92,3 @@ tr:hover {
   background-color: #f5faff;
 }
 
-.filters,
-.categories {
-  margin-bottom: 1rem;
-}
-
-.filters button.active,
-.categories button.active {
-  background-color: #646cff;
-  color: #fff;
-}


### PR DESCRIPTION
## Summary
- limit market query to the top 100 entries
- drop category/source filter controls
- clean up related styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68770ea0ca708321b8d9e6409d04d60d