### PR TITLE
Refactor helpers into common module

### DIFF
--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -44,7 +44,7 @@ def main() -> None:
     rows_e: list[dict] = []
     rows_m: list[dict] = []
     rows_p: list[dict] = []
-
+    rows_s: list[dict] = []
     rows_o: list[dict] = []
 
     for event in events:

--- a/kalshi_update_prices.py
+++ b/kalshi_update_prices.py
@@ -1,10 +1,10 @@
 import os
-import time
 import logging
-import requests
 from datetime import datetime, timedelta, timezone
 from dateutil import parser
-from common import insert_to_supabase, fetch_stats_concurrent
+from common import insert_to_supabase, fetch_stats_concurrent, request_json
+import requests
+import time
 
 # refresh prices for the most active Kalshi markets (24h volume)
 
@@ -30,21 +30,6 @@ TRADES_ENDPOINT = "https://api.elections.kalshi.com/trade-api/v2/markets/{}/trad
 
 
 
-def request_json(url: str, headers=None, params=None, tries: int = 3, backoff: float = 1.5):
-    """GET *url* and return JSON with simple retries."""
-    for i in range(tries):
-        try:
-            r = requests.get(url, headers=headers, params=params, timeout=20)
-            r.raise_for_status()
-            return r.json()
-        except Exception as e:
-            logging.warning("request failed (%s/%s) %s: %s", i + 1, tries, url, e)
-            if i == tries - 1:
-                return None
-            time.sleep(backoff * (2**i))
-
-def fetch_all_markets(limit=1000):
-    markets, seen, offset = [], set(), 0
     while True:
         j = request_json(
             MARKETS_URL,

--- a/polymarket_update_prices.py
+++ b/polymarket_update_prices.py
@@ -1,7 +1,5 @@
 import os
-import time
 import logging
-import requests
 from datetime import datetime, timezone
 from dateutil import parser
 from common import (
@@ -9,7 +7,10 @@ from common import (
     fetch_clob,
     last24h_stats,
     CLOB_URL,
+    request_json,
 )
+import requests
+import time
 
 SUPABASE_URL = os.environ["SUPABASE_URL"]
 SERVICE_KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
@@ -24,20 +25,6 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 
 
 
-
-def request_json(url: str, headers=None, params=None, tries: int = 3, backoff: float = 1.5):
-    for i in range(tries):
-        try:
-            r = requests.get(url, headers=headers, params=params, timeout=20)
-            r.raise_for_status()
-            return r.json()
-        except Exception as e:
-            logging.warning("request failed (%s/%s) %s: %s", i + 1, tries, url, e)
-            if i == tries - 1:
-                return None
-            time.sleep(backoff * (2**i))
-
-# ───────────────── helpers
 # `fetch_clob` and `last24h_stats` are imported from ``common`` so that they
 # respect any environment-based overrides for Polymarket endpoints.
 


### PR DESCRIPTION
## Summary
- add reusable `request_json` with retries
- use the helper in Kalshi and Polymarket price updaters
- initialize `rows_s` in `kalshi_fetch`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6879b53b69a083219bc73db02fa4f6fd