### PR TITLE
Fix fetch_all_markets definition

### DIFF
--- a/kalshi_update_prices.py
+++ b/kalshi_update_prices.py
@@ -29,7 +29,11 @@ MARKETS_URL = "https://api.elections.kalshi.com/trade-api/v2/markets"
 TRADES_ENDPOINT = "https://api.elections.kalshi.com/trade-api/v2/markets/{}/trades"
 
 
-
+def fetch_all_markets(limit: int = 1000) -> list[dict]:
+    """Return a list of all Kalshi markets."""
+    markets: list[dict] = []
+    seen: set[str] = set()
+    offset = 0
     while True:
         j = request_json(
             MARKETS_URL,


### PR DESCRIPTION
## Summary
- restore the `fetch_all_markets` helper that was accidentally removed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6879b7ef20688321ac8ee5c8d9ae03b4