### PR TITLE
Update Kalshi API base

### DIFF
--- a/dateutil/__init__.py
+++ b/dateutil/__init__.py
@@ -1,3 +1,4 @@
-# Minimal stub of dateutil providing only parser.parse used in tests.
-from .parser import parse
-__all__ = ['parse']
+# Minimal stub of dateutil providing only parser.parse/isoparse used in tests.
+from .parser import parse, isoparse
+
+__all__ = ['parse', 'isoparse']

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -1,6 +1,10 @@
 """Lightweight ISO datetime parser for tests."""
 from datetime import datetime
 
+def isoparse(value: str) -> datetime:
+    """Parse an ISO-8601 string."""
+    return parse(value)
+
 def parse(value: str) -> datetime:
     """Parse a subset of ISO-8601 strings."""
     if value.endswith('Z'):

--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -15,14 +15,12 @@ HEADERS_KALSHI = {
     "Content-Type": "application/json",
 }
 
-# Base URL for Kalshi API. Historically the host changed from
-# ``api.elections.kalshi.com`` to ``trading-api.kalshi.com``.  Allow
-# overriding via ``KALSHI_API_BASE`` and fall back to the newer host if
-# the request fails.
+# Base URL for Kalshi API. The default points to ``api.elections.kalshi.com``.
+# ``KALSHI_API_BASE`` can override this value.
 API_BASE = os.environ.get(
     "KALSHI_API_BASE", "https://api.elections.kalshi.com/trade-api/v2"
 )
-FALLBACK_BASE = "https://trading-api.kalshi.com/trade-api/v2"
+FALLBACK_BASE = "https://api.elections.kalshi.com/trade-api/v2"
 
 EVENTS_URL = f"{API_BASE}/events"
 MARKETS_URL = f"{API_BASE}/markets"


### PR DESCRIPTION
## Summary
- update Kalshi base URL and fallback to `api.elections.kalshi.com`
- expose `isoparse` in the `dateutil` test stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d920150fc83219bfff6586140129d