### PR TITLE
Handle new Kalshi event fields

### DIFF
--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -57,13 +57,14 @@ def format_market_row(event: dict, market: dict) -> dict:
     candidate = ticker.split("-")[-1] if ticker else None
     expiration_raw = market.get("close_time") or market.get("closeTime")
     expiration = parse(expiration_raw).isoformat() if expiration_raw else None
-    title = event.get("title") or event.get("ticker")
+    event_ticker = event.get("ticker") or event.get("event_ticker")
+    title = event.get("title") or event_ticker
     return {
         "market_id": ticker,
         "market_name": candidate,
         "market_description": title,
         "event_name": title,
-        "event_ticker": event.get("ticker"),
+        "event_ticker": event_ticker,
         "expiration": expiration,
         "tags": ["kalshi"],
         "source": "kalshi",
@@ -82,7 +83,7 @@ def main() -> None:
     rows_o: list[dict] = []
 
     for event in events:
-        event_ticker = event.get("ticker")
+        event_ticker = event.get("ticker") or event.get("event_ticker")
         title = event.get("title") or event_ticker
         if not event_ticker:
             continue

--- a/tests/test_kalshi_fetch.py
+++ b/tests/test_kalshi_fetch.py
@@ -27,3 +27,16 @@ def test_format_market_row_basic():
     assert row["market_description"] == "Presidential Election"
     assert row["status"] == "TRADING"
     assert row["tags"] == ["kalshi"]
+
+
+def test_format_market_row_event_ticker_fallback():
+    event = {"title": "New Pope", "event_ticker": "EVT-POPE"}
+    market = {
+        "ticker": "EVT-POPE-JOHN",
+        "close_time": "2030-01-01T00:00:00Z",
+    }
+    row = format_market_row(event, market)
+    assert row["market_id"] == "EVT-POPE-JOHN"
+    assert row["market_name"] == "JOHN"
+    assert row["event_ticker"] == "EVT-POPE"
+    assert row["market_description"] == "New Pope"


### PR DESCRIPTION
## Summary
- support `event_ticker` field returned by the elections API
- test that `format_market_row` works with `event_ticker`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687d9baf67b08321841ca1fc0e8cce1a