### PR TITLE
Improve Kalshi API base handling

### DIFF
--- a/common.py
+++ b/common.py
@@ -2,7 +2,25 @@
 Shared helpers for every ingestion script.
 """
 import os
-import requests
+try:
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled in tests
+    class _RequestsPlaceholder:
+        """Minimal placeholder so tests can monkeypatch ``requests``."""
+
+        RequestException = Exception
+
+        def get(self, *a, **kw):  # pragma: no cover - network disabled
+            raise RuntimeError(
+                "The 'requests' library is required for network operations"
+            )
+
+        def post(self, *a, **kw):  # pragma: no cover - network disabled
+            raise RuntimeError(
+                "The 'requests' library is required for network operations"
+            )
+
+    requests = _RequestsPlaceholder()
 import itertools
 import time
 from datetime import datetime, timedelta

--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -23,6 +23,11 @@ HEADERS_KALSHI = {
 API_BASE = os.environ.get(
     "KALSHI_API_BASE", "https://trading-api.kalshi.com/trade-api/v2"
 )
+# Allow specifying the base host without the path. If ``KALSHI_API_BASE``
+# omits the ``/trade-api/v2`` suffix, append it automatically for
+# backwards compatibility.
+if not API_BASE.rstrip('/').endswith("trade-api/v2"):
+    API_BASE = API_BASE.rstrip('/') + '/trade-api/v2'
 FALLBACK_BASE = "https://api.elections.kalshi.com/trade-api/v2"
 
 EVENTS_URL = f"{API_BASE}/events"

--- a/kalshi_update_prices.py
+++ b/kalshi_update_prices.py
@@ -28,6 +28,10 @@ HEADERS_KALSHI = {
 API_BASE = os.environ.get(
     "KALSHI_API_BASE", "https://trading-api.kalshi.com/trade-api/v2"
 )
+# ``KALSHI_API_BASE`` can be provided as just the host. Append the
+# ``/trade-api/v2`` path if it's missing so callers don't need to include it.
+if not API_BASE.rstrip('/').endswith("trade-api/v2"):
+    API_BASE = API_BASE.rstrip('/') + '/trade-api/v2'
 FALLBACK_BASE = "https://api.elections.kalshi.com/trade-api/v2"
 MARKETS_URL = f"{API_BASE}/markets"
 TRADES_ENDPOINT = f"{API_BASE}/markets/{{}}/trades"

--- a/polymarket_update_prices.py
+++ b/polymarket_update_prices.py
@@ -8,7 +8,23 @@ from common import (
     CLOB_URL,
     request_json,
 )
-import requests
+try:
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled in tests
+    class _RequestsPlaceholder:
+        RequestException = Exception
+
+        def get(self, *a, **kw):
+            raise RuntimeError(
+                "The 'requests' library is required for network operations"
+            )
+
+        def post(self, *a, **kw):
+            raise RuntimeError(
+                "The 'requests' library is required for network operations"
+            )
+
+    requests = _RequestsPlaceholder()
 import time
 
 SUPABASE_URL = os.environ["SUPABASE_URL"]


### PR DESCRIPTION
## Summary
- handle missing `requests` dependency by stubbing it for tests
- allow `KALSHI_API_BASE` without path in Kalshi scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f0576b8208321ab37f59757ec1bac