### PR TITLE
Update Kalshi API host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 SUPABASE_URL="https://your-project.supabase.co"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 KALSHI_API_KEY="your-kalshi-api-key"
+KALSHI_API_BASE="https://api.elections.kalshi.com/trade-api/v2"  # optional API endpoint override
 KALSHI_WS_URL="wss://api.elections.kalshi.com/ws/v2"  # optional websocket endpoint
 POLYMARKET_API_KEY="your-polymarket-api-key"
 # Optional overrides when direct access to clob.polymarket.com is blocked

--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -16,21 +16,21 @@ HEADERS_KALSHI = {
     "Content-Type": "application/json",
 }
 
-# Base URL for Kalshi API. The default now points to the stable
-# ``trading-api.kalshi.com`` host. ``KALSHI_API_BASE`` can override this
-# value. ``FALLBACK_BASE`` retains the election specific host for backwards
-# compatibility if the newer host fails.
+# Base URL for Kalshi API. The default now points to the new
+# ``api.elections.kalshi.com`` host. ``KALSHI_API_BASE`` can override this
+# value. ``FALLBACK_BASE`` retains the old host for backwards compatibility
+# if the newer host fails.
 API_BASE = os.environ.get(
-    "KALSHI_API_BASE", "https://trading-api.kalshi.com/trade-api/v2"
+    "KALSHI_API_BASE", "https://api.elections.kalshi.com/trade-api/v2"
 )
-FALLBACK_BASE = "https://api.elections.kalshi.com/trade-api/v2"
+FALLBACK_BASE = "https://trading-api.kalshi.com/trade-api/v2"
 
 EVENTS_URL = f"{API_BASE}/events"
 MARKETS_URL = f"{API_BASE}/markets"
 
 
 def _request_with_fallback(url: str, *, params=None) -> dict | None:
-    """Return JSON from *url* with fallback to the newer API host."""
+    """Return JSON from *url* with fallback to the older API host."""
     j = request_json(url, headers=HEADERS_KALSHI, params=params)
     if j is None and API_BASE != FALLBACK_BASE:
         alt_url = url.replace(API_BASE, FALLBACK_BASE)

--- a/kalshi_update_prices.py
+++ b/kalshi_update_prices.py
@@ -25,15 +25,19 @@ HEADERS_KALSHI = {
     "Content-Type": "application/json",
 }
 
+# Base URL for Kalshi API. Defaults to the new ``api.elections.kalshi.com`` host
+# but can be overridden with ``KALSHI_API_BASE``. ``FALLBACK_BASE`` preserves
+# the old host for backwards compatibility if requests to the new endpoint fail.
 API_BASE = os.environ.get(
-    "KALSHI_API_BASE", "https://trading-api.kalshi.com/trade-api/v2"
+    "KALSHI_API_BASE", "https://api.elections.kalshi.com/trade-api/v2"
 )
-FALLBACK_BASE = "https://api.elections.kalshi.com/trade-api/v2"
+FALLBACK_BASE = "https://trading-api.kalshi.com/trade-api/v2"
 MARKETS_URL = f"{API_BASE}/markets"
 TRADES_ENDPOINT = f"{API_BASE}/markets/{{}}/trades"
 
 
 def _request_with_fallback(url: str, *, params=None) -> dict | None:
+    """Fetch *url* with fallback to the older API host if needed."""
     j = request_json(url, headers=HEADERS_KALSHI, params=params)
     if j is None and API_BASE != FALLBACK_BASE:
         alt_url = url.replace(API_BASE, FALLBACK_BASE)

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Planned: deeper summarization models that track *why* probabilities shift over t
 | `SUPABASE_URL`              | e.g. `https://abcde.supabase.co`      |
 | `SUPABASE_SERVICE_ROLE_KEY` | long service key (server‑side only)   |
 | `KALSHI_API_KEY`            | Kalshi personal API token             |
+| `KALSHI_API_BASE`          | (optional) override base API URL      |
 | `KALSHI_WS_URL`             | (optional) override WebSocket endpoint |
 | `POLYMARKET_API_KEY`        | (optional) higher quota for Gamma API |
 | `POLYMARKET_GAMMA_URL`      | (optional) override for Gamma API     |
@@ -96,6 +97,9 @@ Planned: deeper summarization models that track *why* probabilities shift over t
 | `POLYMARKET_TRADES_URL`     | (optional) proxy base for trades API  |
 
 See **`.env.example`** for a template and add them to **`.env`** for local runs. Store them in **GitHub Secrets** for CI.
+
+The default Kalshi API endpoint is `https://api.elections.kalshi.com/trade-api/v2`. Use
+`KALSHI_API_BASE` if you need to point to a different host.
 
 ### Front-end config
 


### PR DESCRIPTION
## Summary
- default to the new `api.elections.kalshi.com` API host
- keep the old host as a fallback
- expose `KALSHI_API_BASE` in `.env.example` and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f098da0508321a81b3e9545867ae8