### PR TITLE
Limit snapshot market query batch

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -35,7 +35,11 @@ async function loadMarkets() {
 
     if (!rows.length) throw new Error("No rows after filter");
 
-    const idList = rows.map(r => `'${r.market_id}'`).join(",");
+    const MAX_IDS = 200;
+    const idList = rows
+      .slice(0, MAX_IDS)
+      .map(r => `'${encodeURIComponent(r.market_id)}'`)
+      .join(",");
     const since = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
 
     const prevRows = await api(

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -50,7 +50,11 @@ export default function App() {
             '&limit=1000'
         )
         data = data.filter(r => (r.volume ?? 0) > 0)
-        const idList = data.map(r => `'${r.market_id}'`).join(',')
+        const MAX_IDS = 200
+        const idList = data
+          .slice(0, MAX_IDS)
+          .map(r => `'${encodeURIComponent(r.market_id)}'`)
+          .join(',')
         const since = new Date(Date.now() - 24 * 3600 * 1000).toISOString()
         const prevRows = await api(
           `/rest/v1/market_snapshots?select=market_id,price&market_id=in.(${idList})&timestamp=gt.${since}&order=timestamp.desc`


### PR DESCRIPTION
## Summary
- avoid long Supabase queries that trigger 400 errors
- encode each market ID and limit the list to 200

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ce7daa348321a71dbceff30b9c57