### PR TITLE
Add outcome list to latest snapshots

### DIFF
--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -104,6 +104,8 @@ def main() -> None:
 
         markets = fetch_markets(event_ticker)
 
+        event_prices: dict[str, float | None] = {}
+
         for m in markets:
             ticker = m.get("ticker")
             if not ticker:
@@ -163,6 +165,7 @@ def main() -> None:
                 }
             )
 
+            event_prices[candidate] = avg_price
             rows_o.append(
                 {
                     "market_id": ticker,
@@ -173,6 +176,27 @@ def main() -> None:
                     "source": "kalshi",
                 }
             )
+
+        # Add other candidate outcomes so each market shows full choices
+        for m in markets:
+            ticker = m.get("ticker")
+            if not ticker:
+                continue
+            for cand, pr in event_prices.items():
+                if pr is None:
+                    continue
+                if cand == ticker.split("-")[-1]:
+                    continue  # already added above
+                rows_o.append(
+                    {
+                        "market_id": ticker,
+                        "outcome_name": cand,
+                        "price": pr,
+                        "volume": None,
+                        "timestamp": ts,
+                        "source": "kalshi",
+                    }
+                )
 
     insert_to_supabase("events", rows_e)
     insert_to_supabase("markets", rows_m)

--- a/readme.md
+++ b/readme.md
@@ -160,9 +160,11 @@ SQL definitions live in [`schema.sql`](schema.sql).
 The `tags` column is `jsonb`; just pass a Python list (`["econ", "CPI"]`).
 
 The `latest_snapshots` view returns the most recent snapshot per market and the
-timestamp of the first snapshot as `start_date`. The front‑end queries columns
-`market_id`, `source`, `market_name`, `expiration`, `start_date`, `tags`,
-`price`, `volume`, `dollar_volume`, `liquidity` and `timestamp`.
+timestamp of the first snapshot as `start_date`. Each row also includes
+`outcomes`, a JSON array of all choices and their current price. The front‑end
+queries columns `market_id`, `source`, `market_name`, `expiration`,
+`start_date`, `tags`, `price`, `volume`, `dollar_volume`, `liquidity`,
+`timestamp` and `outcomes`.
 
 ## 🖥 Frontend web app
 

--- a/schema.sql
+++ b/schema.sql
@@ -71,9 +71,19 @@ select distinct on (s.market_id)
     s.dollar_volume,
     s.vwap,
     s.liquidity,
-    s.timestamp
+    s.timestamp,
+    coalesce(o.outcomes, '[]'::jsonb) as outcomes
 from market_snapshots s
 join markets m on m.market_id = s.market_id
+left join (
+    select market_id,
+           jsonb_agg(
+               jsonb_build_object('outcome_name', outcome_name, 'price', price)
+               order by outcome_name
+           ) as outcomes
+    from market_outcomes
+    group by market_id
+) o on o.market_id = s.market_id
 join (
     select market_id, min(timestamp) as start_date
     from market_snapshots


### PR DESCRIPTION
## Summary
- include market outcomes table in latest_snapshots view
- replicate full list of outcomes for every Kalshi market
- document new `outcomes` column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d0b657848321afa229f27ade0198