### PR TITLE
Fix Kalshi event insertion

### DIFF
--- a/kalshi_fetch.py
+++ b/kalshi_fetch.py
@@ -198,7 +198,7 @@ def main() -> None:
                     }
                 )
 
-    insert_to_supabase("events", rows_e)
+    insert_to_supabase("events", rows_e, conflict_key="event_id")
     insert_to_supabase("markets", rows_m)
     insert_to_supabase("market_snapshots", rows_s, conflict_key=None)
     insert_to_supabase("market_prices", rows_p, conflict_key=None)


### PR DESCRIPTION
## Summary
- populate `events` table in `kalshi_fetch`
- test that events rows are built correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d954839c8321b753e6607e162e14